### PR TITLE
Read Xml manifest with Utf8 encoding

### DIFF
--- a/Export/Private/Get-D365BCManifestFromAppFile.ps1
+++ b/Export/Private/Get-D365BCManifestFromAppFile.ps1
@@ -229,7 +229,7 @@ function Global:Get-D365BCManifestFromAppFile {
             if ([string]::IsNullOrEmpty($ManifestFileName)) {
                 return
             }
-            [Xml]$xmlManifest = Get-Content -Path $ManifestFileName
+            [Xml]$xmlManifest = Get-Content -Path $ManifestFileName -Encoding UTF8
             if ($SkipCleanup -eq $false) {
                 Write-Verbose "Cleaning up / removing temporary path $((Split-Path $Filename))"
                 Remove-Item (Split-Path $Filename) -Force -Recurse


### PR DESCRIPTION
Resolving an issue where returned values from the NavxManifest.xml containg umlauts/special characters had the wrong encoding.